### PR TITLE
Refactor: Allow modal block to host other Volto blocks

### DIFF
--- a/src/Schema.js
+++ b/src/Schema.js
@@ -7,7 +7,7 @@ export const ModalButtonSchema = (props) => {
       {
         id: 'default',
         title: 'Default',
-        fields: ['iconImage', 'titleText', 'contentText'],
+        fields: ['iconImage', 'titleText', 'modalBlocks'],
       },
     ],
 
@@ -21,11 +21,9 @@ export const ModalButtonSchema = (props) => {
         title: 'Title',
         required: true,
       },
-      contentText: {
-        title: 'Text',
-        widget: 'textarea',
-        type: 'wysiwyg',
-        required: true,
+      modalBlocks: {
+        title: 'Modal Content',
+        type: 'blocks',
       },
     },
     required: [],

--- a/src/View.jsx
+++ b/src/View.jsx
@@ -1,24 +1,28 @@
-import React from 'react'
-import {Button, Header, Icon, Modal} from 'semantic-ui-react'
+import React from 'react';
+import { Button, Header, Icon, Modal } from 'semantic-ui-react';
+import RenderBlocks from '@plone/volto/components/theme/View/RenderBlocks';
 
-function View({data}) {
-  const [open, setOpen] = React.useState(false)
+function View({ data, metadata }) {
+  const [open, setOpen] = React.useState(false);
   return (
     <>
-      <button onClick={() => setOpen(true)}><img src={data.iconImage.file_name} /> {data.titleText}</button>
+      <button onClick={() => setOpen(true)}>
+        {data.iconImage && <img src={data.iconImage.file_name} alt="" />} {/* Added alt attribute for accessibility */}
+        {data.titleText}
+      </button>
       <Modal
         closeIcon
         open={open}
         onClose={() => setOpen(false)}
         onOpen={() => setOpen(true)}
       >
-        <Header icon='archive' content='Archive Old Messages'/>
+        <Header icon="archive" content={data.titleText} />
         <Modal.Content>
-          {data.contentText}
+          <RenderBlocks content={data.modalBlocks} metadata={metadata} />
         </Modal.Content>
       </Modal>
     </>
-  )
+  );
 }
 
-export default View
+export default View;


### PR DESCRIPTION
This change modifies the modal block to enable it to contain any other Volto block.

Key changes:
- Updated `src/Schema.js`: Replaced the `contentText` (WYSIWYG) field with a `modalBlocks` field of type `blocks`. This allows you to add, edit, and manage any standard Volto blocks within the modal's content area.
- Updated `src/View.jsx`: Modified the view component to use Volto's `RenderBlocks` component to render the blocks stored in `modalBlocks`. The modal's header content is now also dynamic, using `data.titleText`.
- The sidebar and edit components (`src/Sidebar.jsx`, `src/Data.jsx`, `src/Edit.jsx`) were reviewed. `BlockDataForm` automatically handles the schema changes, so no direct modifications were needed in these files for the new `modalBlocks` field. The controls for the removed `contentText` field will no longer appear.

This enhancement provides greater flexibility in constructing modal content.