### PR TITLE
feat: Allow modal block to embed any other Volto blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # volto-modal-block
+
+A Volto block that provides a modal dialog. The trigger button for the modal can be configured with an icon and title text.
+
+## Features
+
+- **Configurable Trigger Button:** Customize the appearance of the button that opens the modal by setting an icon and title text.
+- **Embed Any Volto Blocks:** The content of the modal is highly flexible. You can add and arrange any other Volto blocks (text, images, videos, grids, etc.) directly within the modal.
+
+## How to Use
+
+1.  Add the "Modal Button" block to your page.
+2.  In the block settings (usually in the sidebar), configure the "Icon" and "Title" for the button that will trigger the modal.
+3.  In the main block editing area for the Modal Button block, you will see a section labeled "Modal Content" (or similar, based on the schema title for `modalBlocks`).
+4.  Add any Volto blocks you want to display inside the modal into this "Modal Content" area.
+5.  Save the page. Clicking the configured button will now open a modal displaying the blocks you added.


### PR DESCRIPTION
This enhances the modal block to allow you to add, arrange, and render any other Volto blocks within the modal's content area.

Key changes:
- Modified the block schema (`Schema.js`):
    - Removed the `contentText` field (previously a WYSIWYG editor).
    - Added a new `modalBlocks` field of type `blocks`.
- Updated the view component (`View.jsx`):
    - Now uses Volto's `RenderBlocks` component to render the content from the `modalBlocks` field.
    - Made the modal header title dynamic, using the `titleText` field.
    - Added a check for `iconImage` before rendering.
- The block's sidebar (`Sidebar.jsx`, `Data.jsx`) now automatically reflects the schema changes due to the use of `BlockDataForm`.
- Updated `README.md` to describe the new functionality and provide usage instructions.